### PR TITLE
(Don't merge without review!) Allow to build Roboschool using regular Bullet library using BulletRobotics

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ The dependencies are gym, Qt5, assimp, tinyxml, and bullet (from a branch). For 
 Compile and install bullet as follows. Note that `make install` will merely copy files into the roboschool directory.
 
 ```bash
-git clone https://github.com/olegklimov/bullet3 -b roboschool_self_collision
+git clone https://github.com/bulletphysics/bullet3
 mkdir bullet3/build
 cd    bullet3/build
-cmake -DBUILD_SHARED_LIBS=ON -DUSE_DOUBLE_PRECISION=1 -DCMAKE_INSTALL_PREFIX:PATH=$ROBOSCHOOL_PATH/roboschool/cpp-household/bullet_local_install -DBUILD_CPU_DEMOS=OFF -DBUILD_BULLET2_DEMOS=OFF -DBUILD_EXTRAS=OFF  -DBUILD_UNIT_TESTS=OFF -DBUILD_CLSOCKET=OFF -DBUILD_ENET=OFF -DBUILD_OPENGL3_DEMOS=OFF ..
+cmake -DBUILD_SHARED_LIBS=ON -DUSE_DOUBLE_PRECISION=1 -DCMAKE_INSTALL_PREFIX:PATH=$ROBOSCHOOL_PATH/roboschool/cpp-household/bullet_local_install -DBUILD_CPU_DEMOS=OFF -DBUILD_BULLET2_DEMOS=OFF -DBUILD_EXTRAS=ON  -DBUILD_UNIT_TESTS=OFF -DBUILD_CLSOCKET=OFF -DBUILD_ENET=OFF -DBUILD_OPENGL3_DEMOS=OFF ..
 make -j4
 make install
 cd ../..

--- a/roboschool/cpp-household/Makefile
+++ b/roboschool/cpp-household/Makefile
@@ -39,8 +39,8 @@ ifeq ($(UNAME),Darwin)
     MOC =moc
   endif
   PKG   =pkg-config
-  LIBS  =-framework OpenGL
-  INC   =-I/System/Library/Frameworks/OpenGL.framework/Headers
+  LIBS  =-L/usr/local/Cellar/boost-python/1.64.0/lib -framework OpenGL
+  INC   =-I/System/Library/Frameworks/OpenGL.framework/Headers -I/usr/local/include -I/usr/local/opt/qt/include -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenGL.framework/Headers
   BOOST_PYTHON3_POSTFIX = 3
   BOOST_MT=-mt
   PYTHON = $(shell python3 -c "import sys; print('%i.%i' % sys.version_info[:2])")
@@ -49,9 +49,9 @@ endif
 
 $(info Link against python $(PYTHON))
 INC     += `$(PKG) --cflags Qt5Widgets Qt5OpenGL assimp python-$(PYTHON)`
-LIBS    += -lstdc++ `$(PKG) --libs Qt5OpenGL Qt5Widgets assimp python-$(PYTHON)`
+LIBS    += -lstdc++ `$(PKG) --libs Qt5OpenGL Qt5Widgets tinyxml assimp python-$(PYTHON)`
 INC     += -Ibullet_local_install/include -Ibullet_local_install/include/bullet -I/usr/local/include/bullet
-LIBS    += $(RPATH) -Lbullet_local_install/lib -lLinearMath -lBullet3Common -lBulletCollision -lBulletDynamics -lBulletInverseDynamics -lPhysicsClientC_API
+LIBS    += $(RPATH) -Lbullet_local_install/lib -lLinearMath -lBullet3Common -lBulletCollision -lBulletDynamics -lBulletInverseDynamics -lBulletRobotics
 
 ifeq ($(PYTHON),2.7)
     BOOST_PYTHON = -lboost_python

--- a/roboschool/cpp-household/physics-bullet.cpp
+++ b/roboschool/cpp-household/physics-bullet.cpp
@@ -14,7 +14,12 @@ void World::bullet_init(float gravity, float timestep)
 	char* fake_argv[] = { 0 };
 	//client = b3CreateInProcessPhysicsServerAndConnectMainThread(0, fake_argv);
 	//client = b3CreateInProcessPhysicsServerAndConnect(0, fake_argv);
-	client = b3ConnectPhysicsDirect();
+	client = b3ConnectSharedMemory(SHARED_MEMORY_KEY);
+	if (!b3CanSubmitCommand(client))
+        {
+		b3DisconnectSharedMemory(client);
+		client = b3ConnectPhysicsDirect();
+	}
 	settings_gravity = gravity;
 	settings_timestep = timestep;
 	settings_apply();

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ if not os.path.exists(blib):
 from sys import platform
 if platform=="darwin":
     bulletlibs  = "libBullet2FileLoader libBulletCollision libBullet3Collision libBulletDynamics libBullet3Common libBulletInverseDynamics".split()
-    bulletlibs += "libBullet3Dynamics libBulletSoftBody libBullet3Geometry libLinearMath libBullet3OpenCL_clew libPhysicsClientC_API".split()
+    bulletlibs += "libBulletWorldImporter libBulletFileLoader libBulletInverseDynamicsUtils".split()
+    bulletlibs += "libBullet3Dynamics libBulletSoftBody libBullet3Geometry libLinearMath libBullet3OpenCL_clew libBulletRobotics".split()
     for x in bulletlibs:
         os.system("install_name_tool -id @loader_path/cpp-household/bullet_local_install/lib/%s.2.87.dylib %s/%s.2.87.dylib" % (x,blib,x))
         for y in bulletlibs:


### PR DESCRIPTION
I added the Extras/BulletRobotics library so it is easier to build Roboschool out-of-the-box. Note that the self-collision changes are all in the Bullet repo, I don't think you need any custom modifications.

In addition, it contains all the fixes I had to make to run on latest Mac OSX (Sierra 10.12 and High Sierra 10.13).

Finally, this will first try to connect to SHARED_MEMORY, if it fails use DIRECT mode. This will let me easier debug thing outside of Roboschool: spawn a pybullet server in 'connect(p.GUI_SERVER) etc.

If/when you are happy, we could create some tagged release in Bullet, so you don't get surprising regressions.