### PR TITLE
Fix seg fault when multiple environments render

### DIFF
--- a/roboschool/cpp-household/python-binding.cpp
+++ b/roboschool/cpp-household/python-binding.cpp
@@ -162,7 +162,7 @@ shared_ptr<App> app_create_as_needed(const shared_ptr<Household::World>& wref)
 	SimpleRender::opengl_init_before_app(wref);
 	app.reset(new App);
 	the_app = app;
-	SimpleRender::opengl_init(wref->cx);
+	SimpleRender::opengl_init(wref);
 	wref->app_ref = app;
 	return app;
 }

--- a/roboschool/cpp-household/python-binding.cpp
+++ b/roboschool/cpp-household/python-binding.cpp
@@ -156,6 +156,7 @@ shared_ptr<App> app_create_as_needed(const shared_ptr<Household::World>& wref)
 	shared_ptr<App> app = the_app.lock();
 	if (app) {
 		wref->app_ref = app;
+		SimpleRender::opengl_init_existing_app(wref);
 		return app;
 	}
 	SimpleRender::opengl_init_before_app(wref);

--- a/roboschool/cpp-household/render-simple.cpp
+++ b/roboschool/cpp-household/render-simple.cpp
@@ -665,12 +665,14 @@ void opengl_init_before_app(const boost::shared_ptr<Household::World>& wref)
 	fmt.setVersion(4, 1);
 	QSurfaceFormat::setDefaultFormat(fmt);
 	QApplication::setApplicationDisplayName("Roboschool");
-	wref->cx.reset(new SimpleRender::Context(wref));
-	wref->cx->fmt = fmt;
 }
 
-void opengl_init(const boost::shared_ptr<SimpleRender::Context>& cx)
+void opengl_init(const boost::shared_ptr<Household::World>& wref)
 {
+	boost::shared_ptr<SimpleRender::Context>& cx = wref->cx;
+	cx.reset(new SimpleRender::Context(wref));
+	cx->fmt = QSurfaceFormat::defaultFormat();
+	
 	cx->surf = new QOffscreenSurface();
 	cx->surf->setFormat(cx->fmt);
 	cx->surf->create();

--- a/roboschool/cpp-household/render-simple.cpp
+++ b/roboschool/cpp-household/render-simple.cpp
@@ -716,4 +716,23 @@ void opengl_init(const boost::shared_ptr<SimpleRender::Context>& cx)
 	}
 }
 
+void opengl_init_existing_app(const boost::shared_ptr<Household::World>& wref)
+{
+	wref->cx.reset(new SimpleRender::Context(wref));
+	wref->cx->fmt = QSurfaceFormat::defaultFormat();
+	
+	wref->cx->surf = new QOffscreenSurface();
+	wref->cx->surf->setFormat(wref->cx->fmt);
+	wref->cx->surf->create();
+
+	QOpenGLContext* glcx = QOpenGLContext::globalShareContext();
+	QSurfaceFormat fmt_got = glcx->format();
+	int got_version = fmt_got.majorVersion()*1000 + fmt_got.majorVersion();
+	bool ok_all_features    = got_version >= 4001;
+
+	wref->cx->glcx = glcx;
+	wref->cx->ssao_enable = ok_all_features;
+	wref->cx->glcx->makeCurrent(wref->cx->surf);
+}
+
 } // namespace

--- a/roboschool/cpp-household/render-simple.h
+++ b/roboschool/cpp-household/render-simple.h
@@ -221,5 +221,6 @@ private:
 
 extern void opengl_init_before_app(const boost::shared_ptr<Household::World>& wref);
 extern void opengl_init(const boost::shared_ptr<SimpleRender::Context>& cx);
+extern void opengl_init_existing_app(const boost::shared_ptr<Household::World>& wref);
 
 } // namespace

--- a/roboschool/cpp-household/render-simple.h
+++ b/roboschool/cpp-household/render-simple.h
@@ -220,7 +220,7 @@ private:
 };
 
 extern void opengl_init_before_app(const boost::shared_ptr<Household::World>& wref);
-extern void opengl_init(const boost::shared_ptr<SimpleRender::Context>& cx);
+extern void opengl_init(const boost::shared_ptr<Household::World>& wref);
 extern void opengl_init_existing_app(const boost::shared_ptr<Household::World>& wref);
 
 } // namespace


### PR DESCRIPTION
When more than one environments are created and used for rendering, segmentation fault will occur. There are two separate causes to this error, for example when two environments have been created:

1. When the two environments are running concurrently (i.e. initialized and assigned to different variable names), the second environment has uninitialized pointers to the context and surface for rendering. The missing initialization is implemented in the suggested commit 65d661fc9ed521249be1a3bfb384a8d3f055c88e via the _SimpleRender::opengl_init_existing_app_ method. Attached below is the backtrace when the seg fault occurs.
```
(gdb) backtrace
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007ffff6c68f5d in __GI_abort () at abort.c:90
#2  0x00007ffff6c5ef17 in __assert_fail_base (fmt=<optimized out>, assertion=assertion@entry=0x7fffecfa1f71 "px != 0", 
    file=file@entry=0x7fffecfa1db8 "/usr/include/boost/smart_ptr/shared_ptr.hpp", line=line@entry=710, 
    function=function@entry=0x7fffecfa44c0 <boost::shared_ptr<SimpleRender::Context>::operator->() const::__PRETTY_FUNCTION__> "typename boost::detail::sp_member_access<T>::type boost::shared_ptr<T>::operator->() const [with T = SimpleRender::Context; typename boost::detail::sp_member_access<T>::type = SimpleRender::Context*]") at assert.c:92
#3  0x00007ffff6c5efc2 in __GI___assert_fail (assertion=assertion@entry=0x7fffecfa1f71 "px != 0", 
    file=file@entry=0x7fffecfa1db8 "/usr/include/boost/smart_ptr/shared_ptr.hpp", line=line@entry=710, 
    function=function@entry=0x7fffecfa44c0 <boost::shared_ptr<SimpleRender::Context>::operator->() const::__PRETTY_FUNCTION__> "typename boost::detail::sp_member_access<T>::type boost::shared_ptr<T>::operator->() const [with T = SimpleRender::Context; typename boost::detail::sp_member_access<T>::type = SimpleRender::Context*]") at assert.c:101
#4  0x00007fffecf55607 in boost::shared_ptr<SimpleRender::Context>::operator-> (this=<optimized out>) at /usr/include/boost/smart_ptr/shared_ptr.hpp:710
#5  0x00007fffecf6e9b8 in boost::shared_ptr<SimpleRender::Context>::operator-> (this=0x23f2710) at /usr/include/boost/smart_ptr/shared_ptr.hpp:672
#6  Household::Camera::camera_render (this=<optimized out>, cx=..., render_depth=render_depth@entry=false, render_labeling=render_labeling@entry=false, 
    print_timing=<optimized out>) at render-glwidget.cpp:38
#7  0x00007fffecf9b9cf in Camera::render (this=0x7fffe2306100, render_depth=false, render_labeling=false, print_timing=<optimized out>)
    at python-binding.cpp:230
```


2. When the first environment has been deleted, destroyed or simply overridden by the second environment, the segmentation fault arises due to the fact that no _QGuiApplication_ instance exists before the _QFont_ fields of the Context struct of the second environment get instantiated - the default _QGuiApplication_ instance has been destroyed at the the end of the lifetime of the first environment, as it is the base class of _QApplication_. According to [Qt docs](http://doc.qt.io/qt-5/qfont.html), a _QGuiApplication_ instance must exist before a _QFont_ can be used. See the backtrace below for more clarification. Commit 08fca5a8629c54bfe29153fb219eeaa08d472dfd attempts to fix this error, by moving the instantiation of the Context struct to after the instantiation of _QApplication_ for the new environment.
```
(gdb) backtrace
#0  0x00007fffeb80a6df in QGuiApplication::font() () from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5
#1  0x00007fffeb8c1eb1 in QFont::QFont() () from /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5
#2  0x00007fffecf77613 in SimpleRender::Context::Context (this=0x199b4f0, world=...) at render-simple.cpp:118
#3  0x00007fffecf7c675 in SimpleRender::opengl_init_before_app (wref=...) at render-simple.cpp:668
#4  0x00007fffecf86c68 in app_create_as_needed (wref=...) at python-binding.cpp:162
#5  0x00007fffecf9b3a3 in Camera::render (this=0x7fffe22dff10, render_depth=false, render_labeling=false, print_timing=<optimized out>)
    at python-binding.cpp:230
```

Both suggested fixes have been tested on Ubuntu 17.10 (GCC 7 + Python 3.6).