### PR TITLE
Typo

### DIFF
--- a/roboschool/cpp-household/render-simple.cpp
+++ b/roboschool/cpp-household/render-simple.cpp
@@ -729,7 +729,7 @@ void opengl_init_existing_app(const boost::shared_ptr<Household::World>& wref)
 
 	QOpenGLContext* glcx = QOpenGLContext::globalShareContext();
 	QSurfaceFormat fmt_got = glcx->format();
-	int got_version = fmt_got.majorVersion()*1000 + fmt_got.majorVersion();
+	int got_version = fmt_got.majorVersion()*1000 + fmt_got.minorVersion();
 	bool ok_all_features    = got_version >= 4001;
 
 	wref->cx->glcx = glcx;


### PR DESCRIPTION
Same typo as in commit d2eebfce8ca048482f65d63a8b3197d12cead946, but within the method created in commit 808fa2a83b977419c59eca0897c4ea44c44bc89f.