### PR TITLE
solved segfault issue when multiple rendering (#141)

### DIFF
--- a/roboschool/cpp-household/python-binding.cpp
+++ b/roboschool/cpp-household/python-binding.cpp
@@ -153,18 +153,21 @@ static boost::weak_ptr<App> the_app;
 
 shared_ptr<App> app_create_as_needed(const shared_ptr<Household::World>& wref)
 {
-	shared_ptr<App> app = the_app.lock();
-	if (app) {
-		wref->app_ref = app;
-		//SimpleRender::opengl_init_existing_app(wref);
-		return app;
-	}
-	SimpleRender::opengl_init_before_app(wref);
-	app.reset(new App);
-	the_app = app;
-	SimpleRender::opengl_init(wref);
-	wref->app_ref = app;
-	return app;
+    shared_ptr<App> app = the_app.lock();
+    if (app) {
+        wref->app_ref = app;
+        SimpleRender::opengl_init_existing_app(wref);
+        return app;
+    }
+    else 
+    {
+        SimpleRender::opengl_init_before_app(wref);
+        app.reset(new App);
+    }
+    the_app = app;
+    SimpleRender::opengl_init(wref);
+    wref->app_ref = app;
+    return app;
 }
 
 struct PythonKeyCallback: KeyCallback {


### PR DESCRIPTION
Modified **roboschool/cpp-household/python-binding.py**  so that OpenGL is correctly initialized in the two cases (app instance was already allocated or not)