### PR TITLE
Remove close kwarg in render

### DIFF
--- a/roboschool/gym_mujoco_xml_env.py
+++ b/roboschool/gym_mujoco_xml_env.py
@@ -74,9 +74,7 @@ class RoboschoolMujocoXmlEnv(gym.Env):
         self.camera = self.scene.cpp_world.new_camera_free_float(self.VIDEO_W, self.VIDEO_H, "video_camera")
         return s
 
-    def render(self, mode, close):
-        if close:
-            return
+    def render(self, mode):
         if mode=="human":
             self.scene.human_render_detected = True
             return self.scene.cpp_world.test_window()

--- a/roboschool/gym_pong.py
+++ b/roboschool/gym_pong.py
@@ -217,9 +217,7 @@ class RoboschoolPong(gym.Env, SharedMemoryClientEnv):
 
         return state, sum(self.rewards), False, {}
 
-    def render(self, mode, close):
-        if close:
-            return
+    def render(self, mode):
         if mode=="human":
             return self.scene.cpp_world.test_window()
         elif mode=="rgb_array":

--- a/roboschool/gym_urdf_robot_env.py
+++ b/roboschool/gym_urdf_robot_env.py
@@ -84,9 +84,7 @@ class RoboschoolUrdfEnv(gym.Env):
         self.camera = self.scene.cpp_world.new_camera_free_float(self.VIDEO_W, self.VIDEO_H, "video_camera")
         return s
 
-    def render(self, mode, close):
-        if close:
-            return
+    def render(self, mode):
         if mode=="human":
             self.scene.human_render_detected = True
             return self.scene.cpp_world.test_window()

--- a/roboschool/multiplayer.py
+++ b/roboschool/multiplayer.py
@@ -90,12 +90,10 @@ class SharedMemoryClientEnv:
         else:
             raise ValueError("multiplayer server returned invalid string '%s' on reset, probably was shut down" % check)
 
-    def shmem_client_rgb_array(self, mode, close):
+    def shmem_client_rgb_array(self, mode):
         """
         This can render video image for render("rgb_array"), also works using shared memory.
         """
-        if close:
-            return
         if mode=="rgb_array":
             os.write(self.sh_pipe_actready, b'G\n')
             check = self.sh_pipe_obsready.readline()[:-1]


### PR DESCRIPTION
Has been removed upstream over a year ago and can lead to crashes
because the close arg isn't passed.

Fixes #178, @Chris-Carvelli came up with the fix, also see https://github.com/openai/roboschool/issues/178#issuecomment-475508426.