### PR TITLE
RoboschoolInvertedPendulumSwingup starts RoboschoolInvertedPendulum without Swingup

### DIFF
--- a/roboschool/gym_pendulums.py
+++ b/roboschool/gym_pendulums.py
@@ -125,3 +125,6 @@ class RoboschoolInvertedPendulum(RoboschoolMujocoXmlEnv):
 class RoboschoolInvertedPendulumSwingup(RoboschoolInvertedPendulum):
     swingup = True
 
+    def __init__(self, swingup=True):
+        RoboschoolInvertedPendulum.__init__(self, swingup)
+


### PR DESCRIPTION
When we start a RoboschoolInvertedPendulumSwingup-v1 environment, Gym starts a RoboschoolInvertedPendulum-v1 environment instead. This is because the swingup parameter in the class RoboschoolInvertedPendulumSwingup is set incorrectly. 

A new constructor has been added so that RoboschoolInvertedPendulum is called with the correct parameters.